### PR TITLE
Add event sync script, sign-in page, and dev server config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Festify (Next.js)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "festify", "run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "API Server (Express)",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["server/index.js"],
+      "port": 8080
+    }
+  ]
+}

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,19 @@
-REACT_APP_SUPABASE_KEY = your_supabase_key_here
+# ── Supabase ──────────────────────────────────────────────────────────────────
+# Public (used by the Next.js frontend)
+NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 
-REACT_APP_SUPABASE_URL = your_supabase_url_here
+# Server-only service-role key — never expose to the browser
+# Used by the event sync script to write data (bypasses RLS)
+SUPABASE_SERVICE_KEY=your_supabase_service_role_key_here
 
-REACT_APP_EDMTRAIN_KEY=your_api_key_here
-
+# ── Spotify ───────────────────────────────────────────────────────────────────
 SPOTIFY_CLIENT_ID=your_client_id_here
 SPOTIFY_CLIENT_SECRET=your_client_secret_here
 
-GOOGLE_API_KEY = your_google_api_key_here
-GOOGLE_CX = your_google_cx_here
+# ── EDMTrain ──────────────────────────────────────────────────────────────────
+EDMTRAIN_API_KEY=your_edmtrain_api_key_here
+
+# ── Google (optional) ─────────────────────────────────────────────────────────
+GOOGLE_API_KEY=your_google_api_key_here
+GOOGLE_CX=your_google_cx_here

--- a/festify/src/app/auth/callback/route.ts
+++ b/festify/src/app/auth/callback/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Supabase auth callback handler.
+ * Supabase redirects here after email confirmation, magic links, and OAuth flows.
+ * It exchanges the one-time `code` in the URL for a session, then redirects
+ * the user to their intended destination (or home).
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  const next = searchParams.get("next") ?? "/";
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // Something went wrong — redirect to login with an error hint
+  return NextResponse.redirect(`${origin}/auth/login?error=auth_callback_failed`);
+}

--- a/festify/src/app/auth/login/actions.ts
+++ b/festify/src/app/auth/login/actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+
+export async function signIn(
+  _prevState: { error: string } | null,
+  formData: FormData
+) {
+  const email = formData.get("email") as string;
+  const password = formData.get("password") as string;
+
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  redirect("/");
+}

--- a/festify/src/app/auth/login/page.tsx
+++ b/festify/src/app/auth/login/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { signIn } from "./actions";
+
+export default function LoginPage() {
+  const [state, action, isPending] = useActionState(signIn, null);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      {/* Background glow */}
+      <div
+        className="fixed inset-0 pointer-events-none"
+        aria-hidden="true"
+      >
+        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] rounded-full bg-primary/10 blur-[120px]" />
+      </div>
+
+      <div className="w-full max-w-md relative">
+        {/* Logo */}
+        <div className="flex flex-col items-center mb-8">
+          <Link href="/" className="flex items-center gap-2 group mb-6">
+            <Image
+              src="/images/icon.png"
+              alt="Festify"
+              width={40}
+              height={40}
+              className="rounded-xl group-hover:scale-110 transition-transform"
+            />
+            <span className="font-brand text-2xl text-white tracking-wide">
+              Festify
+            </span>
+          </Link>
+          <h1 className="text-2xl font-brand text-white">Welcome back</h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Sign in to your account
+          </p>
+        </div>
+
+        {/* Card */}
+        <div className="glass p-8 rounded-2xl">
+          <form action={action} className="space-y-5">
+            {/* Error message */}
+            {state?.error && (
+              <div className="px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
+                {state.error}
+              </div>
+            )}
+
+            {/* Email */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-foreground"
+              >
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                required
+                placeholder="you@example.com"
+                className={cn(
+                  "w-full px-4 py-2.5 rounded-lg text-sm",
+                  "bg-white/5 border border-white/10",
+                  "text-foreground placeholder:text-muted-foreground",
+                  "focus:outline-none focus:border-primary/60 focus:bg-white/8",
+                  "transition-colors"
+                )}
+              />
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-foreground"
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                required
+                placeholder="••••••••"
+                className={cn(
+                  "w-full px-4 py-2.5 rounded-lg text-sm",
+                  "bg-white/5 border border-white/10",
+                  "text-foreground placeholder:text-muted-foreground",
+                  "focus:outline-none focus:border-primary/60 focus:bg-white/8",
+                  "transition-colors"
+                )}
+              />
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={isPending}
+              className={cn(
+                "w-full py-2.5 rounded-full text-sm font-medium",
+                "gradient-purple text-white",
+                "hover:opacity-90 transition-opacity",
+                "flex items-center justify-center gap-2",
+                "disabled:opacity-60 disabled:cursor-not-allowed"
+              )}
+            >
+              {isPending && <Loader2 size={16} className="animate-spin" />}
+              {isPending ? "Signing in…" : "Sign In"}
+            </button>
+          </form>
+        </div>
+
+        {/* Back link */}
+        <p className="text-center text-sm text-muted-foreground mt-6">
+          <Link href="/" className="hover:text-white transition-colors">
+            ← Back to Festify
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,2 +1,9 @@
-SPOTIFY_CLIENT_ID = ""
-SPOTIFY_CLIENT_SECRET = ""
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# ── Supabase (for sync script) ────────────────────────────────────────────────
+SUPABASE_URL=
+SUPABASE_SERVICE_KEY=
+
+# ── Event sources ─────────────────────────────────────────────────────────────
+EDMTRAIN_API_KEY=

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,10 +9,115 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@supabase/supabase-js": "^2.99.1",
         "axios": "^1.6.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.2"
+      }
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.2.tgz",
+      "integrity": "sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.2.tgz",
+      "integrity": "sha512-xuXQARvjdfB1UPK1yUceZ5EGjOLkVz4rBAaloS9foXiAuseWEdgWBCxkIAFRxGBLGX8Uzo8kseq90jhPb+07Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.2.tgz",
+      "integrity": "sha512-ueiOVkbkTQ7RskwVmjR8zxWYw3VKOMxo1+qep+Dx/SgApqyhWBGd92waQb45tbLc7ydB5x8El8utXOLQTuTojQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.2.tgz",
+      "integrity": "sha512-J6Jm9601dkpZf3+EJ48ki2pM4sFtCNm/BI0l8iEnrczgg+JSEQkMoOW5VSpM54t0pNs69bsz5PTmYJahDZKiIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.2.tgz",
+      "integrity": "sha512-V/FF8kX8JGSefsVCG1spCLSrHdNR/JFeUMn1jS9KG/Eizjx+evtdKQKLJXFgIylY/bKTXKhc2SYDPIGrIhzsug==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.2.tgz",
+      "integrity": "sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.2",
+        "@supabase/functions-js": "2.99.2",
+        "@supabase/postgrest-js": "2.99.2",
+        "@supabase/realtime-js": "2.99.2",
+        "@supabase/storage-js": "2.99.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -458,6 +563,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -759,6 +873,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -770,6 +890,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -793,6 +919,27 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -4,11 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js",
+    "sync": "node scripts/sync-events.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@supabase/supabase-js": "^2.99.1",
     "axios": "^1.6.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/server/scripts/sync-events.js
+++ b/server/scripts/sync-events.js
@@ -1,0 +1,347 @@
+/**
+ * sync-events.js
+ *
+ * Pulls upcoming events from EDMTrain and Resident Advisor and upserts
+ * them — along with their artists and gig links — into Supabase.
+ *
+ * Usage:
+ *   node scripts/sync-events.js
+ *   npm run sync           (from the server/ directory)
+ *
+ * Required env vars (root .env or server/.env):
+ *   SUPABASE_URL           Supabase project URL
+ *   SUPABASE_SERVICE_KEY   Supabase service-role key (bypasses RLS for writes)
+ *   EDMTRAIN_API_KEY       EDMTrain client key
+ */
+
+'use strict';
+
+const path = require('path');
+
+// Load from root .env first, then fall back to server/.env
+require('dotenv').config({ path: path.join(__dirname, '../../.env') });
+require('dotenv').config({ path: path.join(__dirname, '../.env') });
+
+const { createClient } = require('@supabase/supabase-js');
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const DAYS_AHEAD = 90; // How far into the future to pull events
+const RA_PAGE_SIZE = 100; // Max results per RA page (their API caps at 100)
+const RA_RATE_LIMIT_MS = 600; // Pause between RA pages to avoid rate limiting
+
+// ─── Supabase client ─────────────────────────────────────────────────────────
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY
+);
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function getDateRange(daysAhead = DAYS_AHEAD) {
+  const today = new Date();
+  const future = new Date(today.getTime() + daysAhead * 24 * 60 * 60 * 1000);
+  const fmt = (d) => d.toISOString().split('T')[0];
+  return { start: fmt(today), end: fmt(future) };
+}
+
+// ─── Supabase helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Find or create an artist by name. Returns the artist_id.
+ */
+async function upsertArtist(name) {
+  const { data: existing } = await supabase
+    .from('artists')
+    .select('artist_id')
+    .ilike('artist_name', name)
+    .maybeSingle();
+
+  if (existing) return existing.artist_id;
+
+  const { data, error } = await supabase
+    .from('artists')
+    .insert({ artist_name: name })
+    .select('artist_id')
+    .single();
+
+  if (error) throw new Error(`upsertArtist("${name}"): ${error.message}`);
+  return data.artist_id;
+}
+
+/**
+ * Insert or update an event, deduplicating on the source link (edmtrain_link).
+ * Returns the event_id.
+ */
+async function upsertEvent(eventData) {
+  const sourceLink = eventData.edmtrain_link;
+
+  if (sourceLink) {
+    const { data: existing } = await supabase
+      .from('events')
+      .select('event_id')
+      .eq('edmtrain_link', sourceLink)
+      .maybeSingle();
+
+    if (existing) {
+      await supabase
+        .from('events')
+        .update(eventData)
+        .eq('event_id', existing.event_id);
+      return existing.event_id;
+    }
+  }
+
+  const { data, error } = await supabase
+    .from('events')
+    .insert(eventData)
+    .select('event_id')
+    .single();
+
+  if (error) throw new Error(`upsertEvent("${eventData.event_name}"): ${error.message}`);
+  return data.event_id;
+}
+
+/**
+ * Ensure a gig row exists linking an event to an artist.
+ * Silently ignores duplicate-key violations.
+ */
+async function linkArtistToEvent(eventId, artistId) {
+  const { error } = await supabase
+    .from('gigs')
+    .upsert(
+      { event_id: eventId, artist_id: artistId },
+      { onConflict: 'event_id,artist_id', ignoreDuplicates: true }
+    );
+
+  // 23505 = unique_violation; safe to ignore since we're intentionally deduplicating
+  if (error && error.code !== '23505') {
+    throw new Error(`linkArtistToEvent(${eventId}, ${artistId}): ${error.message}`);
+  }
+}
+
+// ─── EDMTrain ─────────────────────────────────────────────────────────────────
+
+async function syncEDMTrain() {
+  console.log('🎵  Syncing EDMTrain...');
+
+  const { start, end } = getDateRange();
+
+  const url = new URL('https://edmtrain.com/api/events');
+  url.searchParams.set('client', process.env.EDMTRAIN_API_KEY);
+  url.searchParams.set('startDate', start);
+  url.searchParams.set('endDate', end);
+
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`EDMTrain HTTP ${res.status}`);
+
+  const json = await res.json();
+  if (!json.success || !json.data) throw new Error('EDMTrain returned no data');
+
+  let synced = 0;
+
+  for (const item of json.data) {
+    try {
+      const eventData = {
+        event_name:        item.name,
+        event_date:        item.date,
+        event_end_date:    item.endDate   || null,
+        event_location:    item.location?.metro || item.location?.state || '',
+        event_venue:       item.location?.name  || '',
+        edmtrain_link:     item.link            || null,
+        festivalInd:       item.festivalInd  === 1,
+        livestreamInd:     item.livestreamInd === 1,
+        electronicGenreInd: true,
+        img_url:   null,
+        alt_img:   null,
+        use_alt:   false,
+      };
+
+      const eventId = await upsertEvent(eventData);
+
+      for (const artist of item.artists ?? []) {
+        const artistId = await upsertArtist(artist.name);
+        await linkArtistToEvent(eventId, artistId);
+      }
+
+      synced++;
+    } catch (err) {
+      console.error(`  ✗  EDMTrain — "${item.name}": ${err.message}`);
+    }
+  }
+
+  console.log(`  ✓  EDMTrain: ${synced} / ${json.data.length} events synced\n`);
+}
+
+// ─── Resident Advisor ─────────────────────────────────────────────────────────
+
+const RA_QUERY = /* GraphQL */ `
+  query GET_EVENT_LISTINGS(
+    $filters: EventListingFilterInputType
+    $pageSize: Int
+    $page: Int
+  ) {
+    eventListings(filters: $filters, pageSize: $pageSize, page: $page) {
+      totalResults
+      data {
+        id
+        listingDate
+        event {
+          id
+          title
+          date
+          startTime
+          endTime
+          images { filename type }
+          venue {
+            id
+            name
+            area {
+              name
+              country { name }
+            }
+          }
+          artists { id name }
+          contentUrl
+        }
+      }
+    }
+  }
+`;
+
+async function fetchRAPage(dateFrom, dateTo, page) {
+  const res = await fetch('https://ra.co/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Referer':      'https://ra.co/',
+      'User-Agent':   'Mozilla/5.0 (compatible; Festify/2.0; +https://github.com/festify)',
+    },
+    body: JSON.stringify({
+      query: RA_QUERY,
+      variables: {
+        filters:  { dateFrom, dateTo },
+        page,
+        pageSize: RA_PAGE_SIZE,
+      },
+    }),
+  });
+
+  if (!res.ok) throw new Error(`RA HTTP ${res.status}`);
+
+  const json = await res.json();
+
+  if (json.errors?.length) {
+    throw new Error(`RA GraphQL error: ${json.errors[0].message}`);
+  }
+
+  return json.data?.eventListings ?? null;
+}
+
+function raImageUrl(images) {
+  if (!images?.length) return null;
+  const main = images.find((img) => img.type === 'main') ?? images[0];
+  return main?.filename ? `https://images.ra.co/${main.filename}` : null;
+}
+
+async function syncRA() {
+  console.log('🎛️   Syncing Resident Advisor (worldwide)...');
+
+  const { start, end } = getDateRange();
+
+  let page = 1;
+  let totalResults = null;
+  let fetched = 0;
+  let synced = 0;
+
+  do {
+    let result;
+    try {
+      result = await fetchRAPage(start, end, page);
+    } catch (err) {
+      console.error(`  ✗  RA page ${page} fetch failed: ${err.message}`);
+      break;
+    }
+
+    if (!result) break;
+
+    if (totalResults === null) {
+      totalResults = result.totalResults;
+      console.log(`  Found ${totalResults} RA listings — fetching in pages of ${RA_PAGE_SIZE}...`);
+    }
+
+    const listings = result.data ?? [];
+    fetched += listings.length;
+
+    for (const listing of listings) {
+      const ev = listing.event;
+      if (!ev) continue;
+
+      try {
+        const location = [ev.venue?.area?.name, ev.venue?.area?.country?.name]
+          .filter(Boolean)
+          .join(', ');
+
+        const eventData = {
+          event_name:        ev.title,
+          event_date:        ev.date?.split('T')[0] ?? ev.date,
+          event_end_date:    null,
+          event_location:    location,
+          event_venue:       ev.venue?.name || '',
+          edmtrain_link:     ev.contentUrl ? `https://ra.co${ev.contentUrl}` : null,
+          festivalInd:       false,
+          livestreamInd:     false,
+          electronicGenreInd: true,
+          img_url:  raImageUrl(ev.images),
+          alt_img:  null,
+          use_alt:  false,
+        };
+
+        const eventId = await upsertEvent(eventData);
+
+        for (const artist of ev.artists ?? []) {
+          const artistId = await upsertArtist(artist.name);
+          await linkArtistToEvent(eventId, artistId);
+        }
+
+        synced++;
+      } catch (err) {
+        console.error(`  ✗  RA — "${ev.title}": ${err.message}`);
+      }
+    }
+
+    console.log(`  Page ${page}: ${synced} synced so far (${fetched} / ${totalResults} fetched)...`);
+    page++;
+
+    if (fetched < totalResults) {
+      await new Promise((r) => setTimeout(r, RA_RATE_LIMIT_MS));
+    }
+  } while (fetched < totalResults);
+
+  console.log(`  ✓  Resident Advisor: ${synced} / ${totalResults} events synced\n`);
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const missing = ['SUPABASE_URL', 'SUPABASE_SERVICE_KEY', 'EDMTRAIN_API_KEY'].filter(
+    (k) => !process.env[k]
+  );
+  if (missing.length) {
+    console.error(`Missing required env vars: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
+  console.log(`\n🚀  Festify event sync  —  ${new Date().toISOString()}\n`);
+
+  try { await syncEDMTrain(); } catch (err) { console.error('EDMTrain sync failed:', err.message); }
+  try { await syncRA();       } catch (err) { console.error('RA sync failed:',       err.message); }
+
+  console.log('✅  Done!');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Event sync** (`server/scripts/sync-events.js`) — pulls upcoming events from EDMTrain and Resident Advisor (worldwide, via RA's internal GraphQL API) into Supabase; upserts artists, links gigs, and deduplicates by source URL. Run with `npm run sync` from `server/`.
- **Sign-in page** (`festify/src/app/auth/login`) — email/password form using a Next.js server action + Supabase `signInWithPassword`; fixes the 404 that the nav's Sign In button was hitting.
- **Auth callback route** (`festify/src/app/auth/callback`) — exchanges Supabase one-time codes for sessions (required for magic links / OAuth).
- **Updated `.env.example`** — modernised to Next.js variable names (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`) and added `SUPABASE_SERVICE_KEY` + `EDMTRAIN_API_KEY`.
- **Dev server config** (`.claude/launch.json`) — saved Festify (:3000) and Express API (:8080) launch configurations.

## Test plan

- [ ] Run `npm install && npm run sync` from `server/` — confirm events and artists appear in Supabase
- [ ] Visit `/auth/login` — confirm the sign-in form renders and the 404 is gone
- [ ] Sign in with a valid Supabase user — confirm redirect to home
- [ ] Sign in with bad credentials — confirm error message displays
- [ ] Copy `.env.example` to `.env` and fill in the new keys before testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)